### PR TITLE
Update EUPL license link in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,7 +31,7 @@ We are all volunteers and completing the process outlined will help us review yo
 1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
 2. I have commented my proposed changes within the code and I have tested my changes.
 3. I am willing to help maintain this change if there are issues with it later.
-4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
+4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
 5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
 6. I have checked that another pull request for this purpose does not exist.
 7. I have considered, and confirmed that this submission will be valuable to others.


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

See bottom of the PR here: https://github.com/pi-hole/pi-hole/pull/6456

> By the way, your link to the EUPL license links to v1.1, instead of 1.2, as the agreement above would suggest.

Seems to be a correct statement. Not sure if we should be pointing to 1.1 and have accidentally linked 1.2, or.. we just didn't update th link


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_