### PR TITLE
Add Contributing.md to be used in all repos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributors Guide
+
+Please read and understand the contribution guide before creating an issue or pull request.
+
+The guide can be found here: [https://docs.pi-hole.net/guides/github/contributing/](https://docs.pi-hole.net/guides/github/contributing/)


### PR DESCRIPTION
Add a `CONTRIBUTING.md` which points to our contributing documentation at https://docs.pi-hole.net.

This file can be used to replace all individual `CONTRIBUTING.md`s in each repo to be able to manage it in a central place.

Details here: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file